### PR TITLE
Adding past notes for Kokkos Kernels open meeting

### DIFF
--- a/meeting_notes/kokkos_kernels_devs/notes/03-27-2025.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/03-27-2025.md
@@ -1,0 +1,42 @@
+# Thursday, March 27, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Junchao, Yuuichi, Colleen, Renzo
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+  - Kokkos User Group (KUG) meeting @HPSF Conf May 5th - 8th
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+
+## Documentation, Communication Structures
+
+  - Documentation now required by github action when making PRs
+  - Adding a template to make it easy to write new documentation (for batch function for instance).
+
+## Release
+- 4.6.0 release tentatively today, although it might wait until Monday for a change in Trilinos...
+- Release briefing upcoming in a couple of weeks: 
+  
+#### To Discuss / Resolve
+
+- refactoring sptrsv eti/tpls:
+  - different function signatures for no-TPL vs TPL code path --> not portable.
+  - current organization of the TPL path makes it difficult to effectively reuse the symbolic step.
+  - only cusparse supported, no rocsparse wrapper so far.
+- refactoring TPL build system
+  - will prioritize using find_package() logic
+  - cleaning up issue with namespace to comply with Trilinos external packages policy
+  - hopefully the two above will help fixing issues with KK build with rocm TPLs using spack
+
+#### Current issues:
+
+
+## Notes:

--- a/meeting_notes/kokkos_kernels_devs/notes/2025-02-27.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025-02-27.md
@@ -1,0 +1,57 @@
+## Thursday, February 27, 2025 Kokkos-Kernels Developer Meeting
+
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+
+- **Note Keeper**
+  
+- **Scientific Meetings / Training / Hackathons**
+  - SIAM CSE, March 3-7 Fort Worth TX
+  - Kokkos User Group (KUG) meeting @HPSF Conf May 5th - 8th
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+  - Setting up new build at OLCF for HIP backend
+  - Junchao: can we get performance tracking as well
+
+## Documentation, Communication Structures
+
+  - New documentation upcoming for 4.6.0
+  - Junchao: can we have tables to show TPL support for each kernels in tables
+  - Yuuichi: can we modify the documentation and does it have batched algorithms.
+
+## Release
+- 4.6.0 release (early March)
+  
+- **Themes**
+   - Promotion of sparse functions out of Experimental namespace
+   - MKL SpADD
+   - Completion of batched band matrix solvers? (gbtrf/gbtrs and refactoring previous ones)
+
+#### To Discuss / Resolve
+
+- refactoring:
+  - [2504](https://github.com/kokkos/kokkos-kernels/pull/2504): Refactor batched serial pbtrs implementation details and tests
+
+- feature request:
+  - [2489](https://github.com/kokkos/kokkos-kernels/pull/2489): Implement batched serial gbtrf
+
+#### Current issues:
+
+- documentation for kokkos-batched:
+
+- Junchao: lack of TPL support for ILU and missing rocSPARSE and MKL support for sparse TRSV
+
+## Notes:
+
+## Attendance
+- Luc Berger-Vergiat
+- Junchao Zhang
+- Yuuichi Asahi
+- Colleen Bartoni
+- Renzo Bustamante

--- a/meeting_notes/kokkos_kernels_devs/notes/2025-03-13.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025-03-13.md
@@ -1,0 +1,53 @@
+## Thursday, February 27, 2025 Kokkos-Kernels Developer Meeting
+
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+
+- **Note Keeper**
+  
+- **Scientific Meetings / Training / Hackathons**
+  - SIAM CSE, March 3-7 Fort Worth TX
+  - Kokkos User Group (KUG) meeting @HPSF Conf May 5th - 8th
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+
+## Documentation, Communication Structures
+
+  - New documentation upcoming for 4.6.0
+  - Junchao: can we have tables to show TPL support for each kernels in tables
+  - Yuuichi: can we modify the documentation and does it have batched algorithms.
+
+## Release
+- 4.6.0 release (early March)
+  
+- **Themes**
+   - Promotion of sparse functions out of Experimental namespace
+   - MKL SpADD
+   - Completion of batched band matrix solvers? (gbtrf/gbtrs and refactoring previous ones)
+
+#### To Discuss / Resolve
+
+- refactoring:
+  - [2530](https://github.com/kokkos/kokkos-kernels/pull/2530): Refactor batched serial pttrf implementation details and tests
+
+- feature request:
+  - [2489](https://github.com/kokkos/kokkos-kernels/pull/2489): Implement batched serial gbtrf
+
+#### Current issues:
+
+- Yuuichi: documentation for kokkos-batched
+
+- Yuuichi: error analysis for unit-testing
+
+- Junchao: lack of TPL support for ILU and missing rocSPARSE and MKL support for sparse TRSV
+
+## Notes:
+
+## Attendance
+

--- a/meeting_notes/kokkos_kernels_devs/notes/2025-03-27.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025-03-27.md
@@ -1,0 +1,53 @@
+# Thursday, March 27, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Junchao, Yuuichi, ~~Colleen~~, ~~Renzo~~, Daniel
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+  - Kokkos User Group (KUG) meeting @HPSF Conf May 5th - 8th
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+
+## Documentation, Communication Structures
+
+  - Documentation now required by github action when making PRs
+  - Adding a template to make it easy to write new documentation (for batch function for instance).
+
+## Release
+
+- 4.6.0 release tentatively today, although it might wait until Monday for a change in Trilinos...
+- Release briefing upcoming in a couple of weeks: 
+
+#### To Discuss / Resolve
+
+- refactoring:
+  - [2555](https://github.com/kokkos/kokkos-kernels/pull/2555): Refactor batched serial pttrs implementation details and tests
+
+- refactoring sptrsv eti/tpls:
+  - different function signatures for no-TPL vs TPL code path --> not portable.
+  - current organization of the TPL path makes it difficult to effectively reuse the symbolic step.
+  - only cusparse supported, no rocsparse wrapper so far.
+
+- refactoring TPL build system
+  - will prioritize using find_package() logic
+  - cleaning up issue with namespace to comply with Trilinos external packages policy
+  - hopefully the two above will help fixing issues with KK build with rocm TPLs using spack
+
+#### Current issues:
+
+- Yuuichi: documentation for kokkos-batched
+
+- Yuuichi: error analysis for unit-testing
+
+- Junchao: lack of TPL support for ILU and missing rocSPARSE and MKL support for sparse TRSV
+
+## Notes:
+

--- a/meeting_notes/kokkos_kernels_devs/notes/2025-05-22.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025-05-22.md
@@ -1,0 +1,59 @@
+# Thursday, March 27, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Junchao, Yuuichi, Colleen, Renzo, Daniel, Carl
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+  - LLNL ElCap Hackathon
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+
+## Documentation, Communication Structures
+
+  - Review documentation propose in PR [#2643](https://github.com/kokkos/kokkos-kernels/pull/2643)
+  - Adopting Yuuichi proposal to use `literalinclude` for examples in the documentation
+  - Plan to move `example/wiki` to `example/docs` as it might make more sense?
+
+## Release
+
+- 4.7.0 release upcoming (end of June/early July?)
+- Is there any specific items you need/want ahead of the release?
+  - Junchao:
+    - fix failing tests on Aurora
+    - rocSparse support for sparse triangular solve
+    - oneMKL support for sparse triangular solve as well if possible
+  - Luc:
+    - get benchmark running daily on Aurora and Frontier
+    - design a dashboard to report performance results
+
+#### To Discuss / Resolve
+
+- Issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+  - Need a bit more investigation to detect why tests are failing and create reproducer(s) in Kokkos Kernels
+  - Build can be reproduced on Blake and likely on Polaris
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628)
+
+- trsv hermitian blocked algorithm
+  - PR [#2651](https://github.com/kokkos/kokkos-kernels/pull/2651)
+
+- refactoring TPL build system
+  - PR [#2547](https://github.com/kokkos/kokkos-kernels/pull/2547)
+  - PR [#2652](https://github.com/kokkos/kokkos-kernels/pull/2652)
+
+#### Current issues:
+
+
+
+## Notes:
+
+- Yuuichi: will start working on examples for complex batch solvers

--- a/meeting_notes/kokkos_kernels_devs/notes/2025-06-05.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025-06-05.md
@@ -1,0 +1,66 @@
+# Thursday, June 05, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Junchao, Yuuichi, Carl
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+  - ISC June 9th
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+
+## Documentation, Communication Structures
+
+  - Review documentation propose in PR [#2643](https://github.com/kokkos/kokkos-kernels/pull/2643) --> Luc rewriting file by file
+  - Plan to move `example/wiki` to `example/docs` as it might make more sense?
+
+## Release
+
+- 4.7.0 release upcoming (end of August)
+- Is there any specific items you need/want ahead of the release?
+  - Junchao:
+    - Can we have testing on Aurora ahead of the release?
+    - Luc: yes, reuse cdash, actually let us setup a nightly build of PETSc against Kokkos Core/Kernels develop version in the kokkos_math project 
+    - fix failing tests on Aurora
+    - rocSparse support for sparse triangular solve (no progress yet)
+    - oneMKL support for sparse triangular solve as well if possible (no progress yet)
+
+  - Luc:
+    - get benchmark running daily on Aurora and Frontier, currently adding features to Kokkos Kernels CMake to help with this
+    - design a dashboard to report performance results, started with google charts
+   
+  - Yuuichi:
+    - want to have batched documentation ready for 5.0.0
+
+#### To Discuss / Resolve
+
+- Issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+  - It looks like two different failure: one triggered by [#2568](https://github.com/kokkos/kokkos-kernels/issues/2568) and [#2580](https://github.com/kokkos/kokkos-kernels/issues/2580)
+  - One issue is related to the extent returned with a rank 0 view see PR [#2667](https://github.com/kokkos/kokkos-kernels/pull/2667)
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628)
+
+- trsv hermitian blocked algorithm
+  - PR [#2651](https://github.com/kokkos/kokkos-kernels/pull/2651), waiting for work on issue #2622 to be resolved before merging
+
+- gbtrs/grbtrf exmaples in PR [#2664](https://github.com/kokkos/kokkos-kernels/pull/2664)
+
+- Yuuichi want to add some documentation for batched banded solvers and related utilities
+
+- refactoring TPL build system
+  - Clean-up call to library ALIAS to fix issue reported by users, see PR [#2652](https://github.com/kokkos/kokkos-kernels/pull/2652)
+  - Remove logic that include TPL into the kokkos:: namespace and instead introduce them in kokkoskernels::
+
+#### Current issues:
+
+
+
+## Notes:

--- a/meeting_notes/kokkos_kernels_devs/notes/2025-06-19.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025-06-19.md
@@ -1,0 +1,73 @@
+# Thursday, June 19, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Junchao, Yuuichi, Daniel
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+  - Making some progress clearing issues in unit-tests, trying to assess if unordered queue is the culprit. Some fences are potentially missing as well.
+  - Will add a build for latest releases of Core and Kernels against latest compiler.
+  - Junchao: could we have more patch releases when issues are discovered and fixed for instance when new compilers are installed. For instance bringing: PR [#2615](https://github.com/kokkos/kokkos-kernels/pull/2615) and [#2688](https://github.com/kokkos/kokkos-kernels/pull/2688) and Core PR [#8051](https://github.com/kokkos/kokkos/pull/8051)
+
+## Documentation, Communication Structures
+
+  - Review documentation propose in PR [#2643](https://github.com/kokkos/kokkos-kernels/pull/2643) --> Luc rewriting file by file
+  - Plan to move `example/wiki` to `example/docs` as it might make more sense?
+  - Review documentation for pttrf/pttrs in PR [#2678](https://github.com/kokkos/kokkos-kernels/pull/2678)
+
+## Release
+
+- 4.7.0 release upcoming (end of August)
+- Is there any specific items you need/want ahead of the release?
+  - Junchao:
+    - Can we have testing on Aurora ahead of the release?
+    - Luc: yes, reuse cdash, actually let us setup a nightly build of PETSc against Kokkos Core/Kernels develop version in the kokkos_math project 
+    - fix failing tests on Aurora
+    - rocSparse support for sparse triangular solve (no progress yet)
+    - oneMKL support for sparse triangular solve as well if possible (no progress yet)
+
+  - Luc:
+    - get benchmark running daily on Aurora and Frontier, currently adding features to Kokkos Kernels CMake to help with this
+    - design a dashboard to report performance results, started with google charts
+   
+  - Yuuichi:
+    - want to have batched documentation ready for 5.0.0
+
+#### To Discuss / Resolve
+
+- Issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+  - It looks like two different failure: one triggered by [#2568](https://github.com/kokkos/kokkos-kernels/issues/2568) and [#2580](https://github.com/kokkos/kokkos-kernels/issues/2580)
+  - One issue is related to the extent returned with a rank 0 view see PR [#2667](https://github.com/kokkos/kokkos-kernels/pull/2667)
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628)
+
+- trsv hermitian blocked algorithm
+  - PR [#2651](https://github.com/kokkos/kokkos-kernels/pull/2651), waiting for work on issue #2622 to be resolved before merging
+
+- Yuuichi want to add some documentation for batched banded solvers and related utilities
+
+- refactoring TPL build system
+  - Clean-up call to library ALIAS to fix issue reported by users, see PR [#2652](https://github.com/kokkos/kokkos-kernels/pull/2652)
+  - Remove logic that include TPL into the kokkos:: namespace and instead introduce them in kokkoskernels::
+
+#### Current issues:
+
+
+
+## Notes:
+
+ - Junchao: is Kokkos Kernels considering sparse direct solver TPLs (cuDSS)?
+ - Yuuichi: CEA is interested as well.
+ - Luc: looking into it but no final decision yet.
+ - Yuuichi: is there a Kokkos Kernels paper in preparation?
+ - Luc: yes, it is almost ready and we are aiming to submit it in July.

--- a/meeting_notes/kokkos_kernels_devs/notes/2025_07_03.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025_07_03.md
@@ -1,0 +1,78 @@
+# Thursday, July 3rd, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Junchao, Yuuichi, Daniel
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+  - Making some progress clearing issues in unit-tests, trying to assess if unordered queue is the culprit. Some fences are potentially missing as well.
+  - Will add a build for latest releases of Core and Kernels against latest compiler.
+  - Junchao: could we have more patch releases when issues are discovered and fixed for instance when new compilers are installed. For instance bringing: PR [#2615](https://github.com/kokkos/kokkos-kernels/pull/2615) and [#2688](https://github.com/kokkos/kokkos-kernels/pull/2688) and Core PR [#8051](https://github.com/kokkos/kokkos/pull/8051)
+
+  - Fixed issue with Polaris, now turning on benchmark tests to monitor performance.
+  - 
+
+## Documentation, Communication Structures
+
+  - Review documentation propose in PR [#2643](https://github.com/kokkos/kokkos-kernels/pull/2643) --> Luc rewriting file by file
+  - Plan to move `example/wiki` to `example/docs` as it might make more sense?
+  - Review documentation for pttrf/pttrs in PR [#2678](https://github.com/kokkos/kokkos-kernels/pull/2678)
+
+## Release
+
+- 4.7.0 release upcoming (end of August)
+- Is there any specific items you need/want ahead of the release?
+  - rocSparse support for sparse triangular solve (no progress yet)
+  - oneMKL support for sparse triangular solve as well if possible (no progress yet)
+  - design a dashboard to report performance results, started with google charts --> some progress here, working on it in my fork
+  - get benchmark running daily on Aurora and Frontier --> adding them on Polaris as a start, need to push results somewhere...
+  - want to have batched documentation ready for 5.0.0
+
+#### To Discuss / Resolve
+
+- Issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+  - It looks like two different failure: one triggered by [#2568](https://github.com/kokkos/kokkos-kernels/issues/2568) and [#2580](https://github.com/kokkos/kokkos-kernels/issues/2580)
+  - One issue is related to the extent returned with a rank 0 view see PR [#2667](https://github.com/kokkos/kokkos-kernels/pull/2667)
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628)
+
+- trsv hermitian blocked algorithm
+  - PR [#2651](https://github.com/kokkos/kokkos-kernels/pull/2651), waiting for work on issue #2622 to be resolved before merging
+
+- Yuuichi want to add some documentation for batched banded solvers and related utilities
+
+- refactoring TPL build system
+  - Clean-up call to library ALIAS to fix issue reported by users, see PR [#2652](https://github.com/kokkos/kokkos-kernels/pull/2652)
+  - Remove logic that include TPL into the kokkos:: namespace and instead introduce them in kokkoskernels::
+ 
+- Junchao:
+  - Kokkos does not support "big binnaries", i.e. you only compile for a single CUDA architecture. --> Luc will discuss this at leader's meeting on Monday
+
+- Hari:
+  - working on benchmarking the library on A500 GPU within the "Trust platform" a library for CFD simulations.
+  - with Remi, creating a solver market that would allow you to pick solvers between different libraries.
+  - having an issue with Tacho, a link error happening with CUDA backend.
+  - trilinos getting started tutorials are not kept up to date.
+  - interested in cuDSS for Trust.
+  - RCM reordering in Kokkos Kernels with GMRES, comparing AMGX with ILU, slow convergence observed with ILU.
+
+#### Current issues:
+
+
+## Notes:
+
+ - Junchao: is Kokkos Kernels considering sparse direct solver TPLs (cuDSS)? --> also used at CEA so second user for CFD
+ - Yuuichi: CEA is interested as well.
+ - Luc: looking into it but no final decision yet.
+ - Yuuichi: is there a Kokkos Kernels paper in preparation?
+ - Luc: yes, it is almost ready and we are aiming to submit it in July.

--- a/meeting_notes/kokkos_kernels_devs/notes/2025_07_31.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025_07_31.md
@@ -1,0 +1,81 @@
+# Thursday, July 31rd, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Colleen, Yuuichi, Hari
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+  - Making some progress clearing issues in unit-tests, trying to assess if unordered queue is the culprit. Some fences are potentially missing as well.
+  - Software update coming soon: Intel 2025.2, Colleen reports that it fixes some of the Kokkos Kernels failing tests. Yay!
+    - The new toolchain will become default in the near future (maybe about two weeks).
+    - Currently the new modules can be load as follows:
+```
+module unload mpich oneapi
+module use /soft/compilers/oneapi/2025.2.0/modulefiles
+module use /soft/compilers/oneapi/nope/modulefiles
+module add oneapi/public/2025.2.0 
+module add mpich/nope/develop-git.6037a7a
+```
+
+## Documentation, Communication Structures
+
+  - Review documentation propose in PR [#2643](https://github.com/kokkos/kokkos-kernels/pull/2643) --> Probably will abandon this one in favor of PR [#2678](https://github.com/kokkos/kokkos-kernels/pull/2678)
+  - Plan to move `example/wiki` to `example/docs` as it might make more sense?
+  - Review documentation for pttrf/pttrs in PR [#2678](https://github.com/kokkos/kokkos-kernels/pull/2678) --> Yuuichi will split some of the explanations in batched/index.rst into batched/dense/index.rst and batched/sparse/indext.rst
+
+## Release
+
+- 4.7.0 release upcoming (next week)
+- Is there any specific items you need/want ahead of the release?
+  - rocSparse support for sparse triangular solve (pushed to 4.8.0)
+  - oneMKL support for sparse triangular solve as well if possible (pushed to 4.8.0)
+- There will be a 4.8.0 release
+  - Prioritize fixing the gemm transpose conjugate problem related to issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+- want to have batched documentation ready for 5.0.0
+
+#### To Discuss / Resolve
+
+- Issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+  - Sub issue related to sptrsv reuse of the symbolic phase is fixed
+  - Sub issue related to gemm transpose conjugate was postponned by reverting changes to release candidate
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628)
+
+- trsv hermitian blocked algorithm
+  - PR [#2651](https://github.com/kokkos/kokkos-kernels/pull/2651), waiting for work on issue #2622 to be resolved before merging
+
+- Yuuichi want to add some documentation for batched banded solvers and related utilities
+
+- refactoring TPL build system
+  - Remove logic that include TPL into the kokkos:: namespace and instead introduce them in kokkoskernels::
+  - New logic in PR for BLAS support using CMake package, currently testing it with Apple Accelerate
+ 
+- Junchao:
+  - Kokkos does not support "big binnaries", i.e. you only compile for a single CUDA architecture. --> Luc asked and there is still no immediate plan, some technical incompatibilities in NVIDIA's toolchain are driving this issue
+
+- Hari:
+  - working on benchmarking the library on A500 GPU within the "Trust platform" a library for CFD simulations.
+  - with Remi, creating a solver market that would allow you to pick solvers between different libraries.
+  - having an issue with Tacho, a link error happening with CUDA backend. --> testing with 3 matrices 100k, 2M and 42M nnz, the two smallest matrix work fine. Getting out of memory error for largest matrix even with AMD re-ordering.
+  - trilinos getting started tutorials are not kept up to date.
+  - interested in cuDSS for Trust.
+  - RCM reordering in Kokkos Kernels with GMRES, comparing AMGX with ILU, slow convergence observed with ILU.
+
+#### Current issues:
+
+
+## Notes:
+
+ - Yuuichi: is there a Kokkos Kernels paper in preparation?
+ - Luc: yes, it is almost ready and we are aiming to submit it in July.
+ - Yuuichi and Hari will be on vacation for next meeting on Aug 14th.

--- a/meeting_notes/kokkos_kernels_devs/notes/2025_08_14.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025_08_14.md
@@ -1,0 +1,86 @@
+# Thursday, August 14th, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Colleen, Yuuichi, Junchao
+
+Luc: September 25th at DOE/MEXT meeting in Chicago
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels
+  - Software update coming soon: Intel 2025.2, Colleen reports that it fixes some of the Kokkos Kernels failing tests. Yay!
+    - The new toolchain will become default in the near future (maybe about two weeks).
+    - Currently the new modules can be load as follows:
+    - Luc confirms on Aurora build that tests are back to normal.
+    - Additional issue detected with 2025.2.0: Kokkos Kernels fails with OpenMP and -O3, works with -O2
+```
+module unload mpich oneapi
+module use /soft/compilers/oneapi/2025.2.0/modulefiles
+module use /soft/compilers/oneapi/nope/modulefiles
+module add oneapi/public/2025.2.0 
+module add mpich/nope/develop-git.6037a7a
+```
+  - Junchao: observed a hang in PETSc with Kokkos Core/Kernels 4.7.00
+  - Yuuichi: would like to join the allocation at ALCF to test Kokkos FFT kernels.
+
+## Documentation, Communication Structures
+
+  - Making this meeting's notes public on kokkos.org
+  - Review documentation propose in PR [#2643](https://github.com/kokkos/kokkos-kernels/pull/2643) --> Probably will abandon this one in favor of PR [#2678](https://github.com/kokkos/kokkos-kernels/pull/2678)
+  - Plan to move `example/wiki` to `example/docs` as it might make more sense?
+  - Review documentation for pttrf/pttrs in PR [#2678](https://github.com/kokkos/kokkos-kernels/pull/2678) --> Yuuichi will split some of the explanations in batched/index.rst into batched/dense/index.rst and batched/sparse/indext.rst
+
+## Release
+
+- Is there any specific items you need/want ahead of the release?
+  - rocSparse support for sparse triangular solve (pushed to 4.8.0)
+  - oneMKL support for sparse triangular solve as well if possible (pushed to 4.8.0)
+- There will be a 4.8.0 release
+  - Prioritize fixing the gemm transpose conjugate problem related to issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+- want to have batched documentation ready for 5.0.0 --> Yuuichi started the work on bathed_dense_index, should be plenty of time to make it for 4.8.0/5.0.0
+- Will look at CUDA 13 support adding a CI test for Core and Kernels.
+
+#### To Discuss / Resolve
+
+- Issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+  - Sub issue related to gemm transpose conjugate will target a resolution in 4.8.00
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628)
+
+- trsv hermitian blocked algorithm
+  - PR [#2651](https://github.com/kokkos/kokkos-kernels/pull/2651), waiting for work on issue #2622 to be resolved before merging
+
+- Yuuichi want to add some documentation for batched banded solvers and related utilities
+
+- refactoring TPL build system
+  - Remove logic that include TPL into the kokkos:: namespace and instead introduce them in kokkoskernels::
+  - New logic in PR for BLAS support using CMake package, currently testing it with Apple Accelerate
+  - Support for AMD AOCL (CPU libraries) for PETSc customer (easy to do for BLAS, sparse will need more time)
+ 
+- Junchao:
+  - Kokkos does not support "big binnaries", i.e. you only compile for a single CUDA architecture. --> Luc asked and there is still no immediate plan, some technical incompatibilities in NVIDIA's toolchain are driving this issue
+
+- Hari:
+  - working on benchmarking the library on A500 GPU within the "Trust platform" a library for CFD simulations.
+  - with Remi, creating a solver market that would allow you to pick solvers between different libraries.
+  - having an issue with Tacho, a link error happening with CUDA backend. --> testing with 3 matrices 100k, 2M and 42M nnz, the two smallest matrix work fine. Getting out of memory error for largest matrix even with AMD re-ordering.
+  - trilinos getting started tutorials are not kept up to date.
+  - interested in cuDSS for Trust.
+  - RCM reordering in Kokkos Kernels with GMRES, comparing AMGX with ILU, slow convergence observed with ILU.
+
+#### Current issues:
+
+
+## Notes:
+
+ - Yuuichi: is there a Kokkos Kernels paper in preparation?
+ - Luc: yes, it is almost ready and we are aiming to submit it in August.

--- a/meeting_notes/kokkos_kernels_devs/notes/2025_08_28.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025_08_28.md
@@ -1,0 +1,99 @@
+# Thursday, August 28th, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, Colleen, Yuuichi, Junchao, Hari
+
+Junchao: September 11th, travel to ICPP
+
+Luc: September 25th at DOE/MEXT meeting in Chicago
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels --> Polaris is down and has been reporting various issues, will check when it is back up
+  - Software update coming soon: Intel 2025.2, Colleen reports that it fixes some of the Kokkos Kernels failing tests. Yay!
+    - The new toolchain will become default in the near future (maybe about two weeks).
+    - Currently the new modules can be load as follows:
+    - Luc confirms on Aurora build that tests are back to normal.
+    - Additional issue detected with 2025.2.0: Kokkos Kernels fails with OpenMP and -O3, works with -O2
+```
+module unload mpich oneapi
+module use /soft/compilers/oneapi/2025.2.0/modulefiles
+module use /soft/compilers/oneapi/nope/modulefiles
+module add oneapi/public/2025.2.0 
+module add mpich/nope/develop-git.6037a7a
+```
+  - Junchao: observed a hang in PETSc with Kokkos Core/Kernels 4.7.00
+    - Colleen reports that the hang is now gone
+    - Luc will look into adding a github action using [this](https://hub.docker.com/r/intel/oneapi) container layer to test with intel 2025.2
+  - Yuuichi: would like to join the allocation at ALCF to test Kokkos FFT kernels.
+
+## Documentation, Communication Structures
+
+  - Making this meeting's notes public on kokkos.org
+    - PR [#193](https://github.com/kokkos/kokkos.github.io/pull/193) is adding information on the website about this meeting ahead of getting the minutes published publicly, please review and give feedback
+  - Merged PR [#2678](https://github.com/kokkos/kokkos-kernels/pull/2678) adding documentation for batched algorithms
+  - Adding PR [2748](https://github.com/kokkos/kokkos-kernels/pull/2748) to add docs for batched pbtrf/pbtrs
+  - Adding PR [2749](https://github.com/kokkos/kokkos-kernels/pull/2749) to clean things up a bit
+  - Plan to move `example/wiki` to `example/docs` as it might make more sense?
+  - Will add PR to make tables for Sparse algorithms and show TPL support on the index page
+  - In general more explanations about TPL support would be nice: what type combination lead to TPL, how are we supporting analyze/compute phases, etc...
+
+## Release
+
+- Is there any specific items you need/want ahead of the release?
+  - rocSparse support for sparse triangular solve (4.7.1), Vinh working on it
+  - oneMKL support for sparse triangular solve as well (4.7.1) Luc starting
+- There will not be a 4.8.0 release but 4.7.1 instead
+  - Prioritize fixing the gemm transpose conjugate problem related to issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+- want to have batched documentation ready for 5.0.0 --> Yuuichi started the work on bathed_dense_index, should be plenty of time to make it for 4.8.0/5.0.0
+- Will look at CUDA 13 support adding a CI test for Core and Kernels.
+- Starting to upgrade CI for full c++20 support and new compiler/toolchain/cmake requirements
+
+#### To Discuss / Resolve
+
+- Issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+  - Sub issue related to gemm transpose conjugate will target a resolution in 4.7.1
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628)
+
+- trsv hermitian blocked algorithm
+  - PR [#2651](https://github.com/kokkos/kokkos-kernels/pull/2651), waiting for work on issue #2622 to be resolved before merging
+
+- Yuuichi want to add some documentation for batched banded solvers and related utilities
+  - How to list batched functions? Make BLAS and LAPACK tables separately?
+  - Luc: Yes, two table is fine
+  - How to manage Serial/Team/TeamVector? In a single page?
+  - Luc: let us add columns in the tables to indicate support for Serial, Team and TeamVector
+
+- refactoring TPL build system
+  - Remove logic that include TPL into the kokkos:: namespace and instead introduce them in kokkoskernels::
+  - New logic in PR for BLAS support using CMake package, currently testing it with Apple Accelerate
+  - Support for AMD AOCL (CPU libraries) for PETSc customer (easy to do for BLAS, sparse will need more time)
+ 
+- Junchao:
+  - Kokkos does not support "big binnaries", i.e. you only compile for a single CUDA architecture. --> Luc asked and there is still no immediate plan, some technical incompatibilities in NVIDIA's toolchain are driving this issue
+
+- Hari:
+  - working on benchmarking the library on A500 GPU within the "Trust platform" a library for CFD simulations.
+  - with Remi, creating a solver market that would allow you to pick solvers between different libraries.
+  - having an issue with Tacho, a link error happening with CUDA backend. --> testing with 3 matrices 100k, 2M and 42M nnz, the two smallest matrix work fine. Getting out of memory error for largest matrix even with AMD re-ordering.
+  - trilinos getting started tutorials are not kept up to date.
+  - interested in cuDSS for Trust.
+  - RCM reordering in Kokkos Kernels with GMRES, comparing AMGX with ILU, slow convergence observed with ILU.
+
+#### Current issues:
+
+
+## Notes:
+
+ - Yuuichi: is there a Kokkos Kernels paper in preparation?
+ - Luc: yes, it is almost ready and we are aiming to submit it in August.

--- a/meeting_notes/kokkos_kernels_devs/notes/2025_09_11.md
+++ b/meeting_notes/kokkos_kernels_devs/notes/2025_09_11.md
@@ -1,0 +1,85 @@
+# Thursday, September 11th, 2025 Kokkos-Kernels Developer Meeting
+
+## Attendance
+Luc, ~~Colleen~~, Yuuichi, ~~Junchao~~, Hari
+
+Luc: September 25th at DOE/MEXT meeting in Chicago
+
+## Linux Foundation Meeting Link
+
+https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524
+
+## Community
+  
+- **Scientific Meetings / Training / Hackathons**
+
+## Nightly Testing
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos+Kernels --> Polaris and Aurora are down and has been reporting various issues, will check when it is back up
+  - Software update coming soon: Intel 2025.2, Colleen reports that it fixes some of the Kokkos Kernels failing tests. Yay!
+    - The new toolchain will become default in the near future (maybe about two weeks).
+    - Currently the new modules can be load as follows:
+    - Luc confirms on Aurora build that tests are back to normal.
+    - Additional issue detected with 2025.2.0: Kokkos Kernels fails with OpenMP and -O3, works with -O2
+```
+module unload mpich oneapi
+module use /soft/compilers/oneapi/2025.2.0/modulefiles
+module use /soft/compilers/oneapi/nope/modulefiles
+module add oneapi/public/2025.2.0 
+module add mpich/nope/develop-git.6037a7a
+```
+
+## Documentation, Communication Structures
+
+  - Making this meeting's notes public on kokkos.org
+    - PR [#193](https://github.com/kokkos/kokkos.github.io/pull/193) is adding information on the website about this meeting ahead of getting the minutes published publicly, please review and give feedback
+  - Merged PR [2748](https://github.com/kokkos/kokkos-kernels/pull/2748) to add docs for batched pbtrf/pbtrs
+  - Merged PR [2749](https://github.com/kokkos/kokkos-kernels/pull/2749) to clean things up a bit
+  - Plan to move `example/wiki` to `example/docs` as it might make more sense?
+  - Will add PR to make tables for Sparse algorithms and show TPL support on the index page
+  - Will add PR to document gesv and svd
+  - Need to add a PR to document sparse batched kernels
+  - In general more explanations about TPL support would be nice: what type combination lead to TPL, how are we supporting analyze/compute phases, etc...
+
+## Release
+
+- Is there any specific items you need/want ahead of the release?
+  - rocSparse support for sparse triangular solve (4.7.2), Ichi working on it
+  - oneMKL support for sparse triangular solve as well (4.7.2) Luc starting
+- There will not be a 4.8.0 release but 4.7.2 instead
+  - Prioritize fixing the gemm transpose conjugate problem related to issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+- want to have batched documentation ready for 5.0.0 --> Yuuichi started the work on bathed_dense_index, should be plenty of time to make it for 4.7.2/5.0.0
+- Will look at CUDA 13 support adding a CI test for Core and Kernels.
+- Starting to upgrade CI for full c++20 support and new compiler/toolchain/cmake requirements.
+
+#### To Discuss / Resolve
+
+- Issue [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)
+  - Sub issue related to gemm transpose conjugate will target a resolution in 4.7.1
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628)
+
+- trsv hermitian blocked algorithm
+  - PR [#2651](https://github.com/kokkos/kokkos-kernels/pull/2651), waiting for work on issue #2622 to be resolved before merging
+
+- refactoring TPL build system
+  - Remove logic that include TPL into the kokkos:: namespace and instead introduce them in kokkoskernels::
+  - New logic in PR for BLAS support using CMake package, currently testing it with Apple Accelerate
+  - Support for AMD AOCL (CPU libraries) for PETSc customer (easy to do for BLAS, sparse will need more time)
+
+- Hari:
+  - working on benchmarking the library on A500 GPU within the "Trust platform" a library for CFD simulations.
+  - with Remi, creating a solver market that would allow you to pick solvers between different libraries.
+  - having an issue with Tacho, a link error happening with CUDA backend. --> testing with 3 matrices 100k, 2M and 42M nnz, the two smallest matrix work fine. Getting out of memory error for largest matrix even with AMD re-ordering.
+  - trilinos getting started tutorials are not kept up to date.
+  - interested in cuDSS for Trust.
+  - RCM reordering in Kokkos Kernels with GMRES, comparing AMGX with ILU, slow convergence observed with ILU.
+
+#### Current issues:
+
+
+## Notes:
+
+ - Yuuichi: is there a Kokkos Kernels paper in preparation?
+ - Luc: yes, it is almost ready and we are aiming to submit it in August.


### PR DESCRIPTION
Moving forward we will try to have the agenda posted early on and notes may or may not be completely seperated from the agenda?