### PR TITLE
Add meeting notes for Kokkos Developer Meeting on 2025-10-29

### DIFF
--- a/meeting_notes/kokkos-core/dev-meeting/2025/2025-10-29.md
+++ b/meeting_notes/kokkos-core/dev-meeting/2025/2025-10-29.md
@@ -1,0 +1,95 @@
+## Wednesday, October 29, 2025 Kokkos Developer Meeting
+
+
+## Linux Foundation Meeting Link
+
+https://zoom.us/j/98700099329?pwd=YhQn5LG1a8GSKTq2a4bxXMfy6OA0Ka.1
+
+## Community
+
+- New developers mailing lists
+  - Please register to get meeting invites
+  - https://lists.hpsf.io/g/kokkos-core-dev
+  - https://lists.hpsf.io/g/kokkos-kernels-dev
+- Upcoming trainings
+  - Kokkos tutorial accepted at SCA/HPCAsia 2026 (January 26-29 in Osaka, Japan)
+  - Kokkos guest lecture (virtual) at Georgia Tech on Nov 12 (Damien)
+  - Kokkos training (1 day course + 3 days hackathon) at CEA (Januray 12-16)
+- HPSF Conference: March 16th-20th again in Chicago
+  - 2 days of KUG Thursday and Friday this time
+
+- **Note Keeper**
+  - 
+
+- **Absences**
+  - Jakob
+    - October 26th - October 31st (vacation)
+  - Damien
+    - November 3rd - November 8th (ISO C++ meeting)
+    - November 16th - Novermber 21st (SC 25)
+  - Christian
+    - November 3rd - November 8th (ISO C++ meeting)
+    - November 16th - Novermber 21st (SC 25)
+    - December 1st week - Washington DC
+  - Patrick
+    - November 16th - Novermber 21st (SC 25)
+
+- Meetings one hour earlier:
+  - October 29th
+
+## CI & Nightly Testing
+
+  - [![gitlab](https://gitlab.spack.io/kokkos/kokkos/badges/develop/pipeline.svg?&key_text=GitLab(GH200,PVC,MI300A)&key_width=160)](https://gitlab.spack.io/kokkos/kokkos/-/pipelines?page=1&scope=all&ref=develop)
+  - [![jenkins-nightly](https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos_nightly/badge/icon?style=plastic&subject=jenkins-nightly)](https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos_nightly/lastCompletedBuild/pipeline-overview/)
+  - [![workflows/staged](https://github.com/kokkos/kokkos/actions/workflows/continuous-integration-stager.yml/badge.svg?branch=develop)](https://github.com/kokkos/kokkos/actions/workflows/continuous-integration-stager.yml?query=branch%3Adevelop)
+  - [![workflows/performance-benchmark](https://github.com/kokkos/kokkos/actions/workflows/performance-benchmark.yml/badge.svg?branch=develop)](https://github.com/kokkos/kokkos/actions/workflows/performance-benchmark.yml?query=branch%3Adevelop)
+  - [![kokkos-core-wiki](https://github.com/kokkos/kokkos-core-wiki/actions/workflows/deploy_docs.yml/badge.svg?branch=main)](https://github.com/kokkos/kokkos-core-wiki/actions/workflows/deploy_docs.yml?query=branch%3Amain)
+  - [![Nightly CEA builds](https://github.com/kokkos/kokkos/actions/workflows/nightly-cea.yml/badge.svg)](https://github.com/kokkos/kokkos/actions/workflows/nightly-cea.yml)
+
+  - CDash at https://my.cdash.org/index.php?project=Kokkos
+
+## 4.7.2 Release
+  - Span of 0-sized, padded views produces incorrect values: https://github.com/kokkos/kokkos/issues/8460
+  - Fix compiling with nvcc-13 and C++20: https://github.com/kokkos/kokkos/pull/8562
+
+## 5.0 CI and Code Prep
+
+  [Kokkos-5.0 CHANGELOG](https://github.com/kokkos/kokkos/issues/8265)
+  
+  ### Release Planning
+  - Release Manager: Trevis
+
+## To Discuss / Resolve
+
+approved pull requests: https://github.com/kokkos/kokkos/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen+review%3Aapproved
+  
+### Priority
+
+- MDRangePolicy performance improvement is high priority
+  
+## Publications
+
+- Possible papers we could focus on
+  - JOSS Kokkos 4 paper
+  - New Kokkos ecosystem paper mentioning new efforts and the transition to HPSF
+    - waiting for Comm blog post, and maybe Fortran Inerop
+  - Maybe a paper to describe how Kokkos is evolving in response to the unified memory advent (APUs, HMM, etc.)
+- Technical blog posts
+
+## Bigger discussions
+- [7319](https://github.com/kokkos/kokkos/issues/7319): Systematic API review for deprecation in preparation of Kokkos 5.0
+  - [7532](https://github.com/kokkos/kokkos/issues/7532): `create_mirror*` functions
+- backend-specific properties:
+  - [6496](https://github.com/kokkos/kokkos/pull/6496): SYCL: Allow setting subgroup size
+- type-safe scratch memory space:
+  - [5879](https://github.com/kokkos/kokkos/pull/5879): Allow specifying scratch level for ScratchSpace at compile-time
+- memory space design:
+  - [6835](https://github.com/kokkos/kokkos/pull/6835): Remove MemorySpace::[de]allocate overloads without labels
+  - [6918](https://github.com/kokkos/kokkos/issues/6918): kokkos_malloc should accept an execution space instance
+- Rethink the containers: They were designed in another age and it would be good to revise/rethink them. This might be a discussion for the time of v5-v6.
+- MDSpan precondition error handlilng https://github.com/kokkos/kokkos/pull/8320 (Nicolas)
+ - Blog posts for releases? (Nicolas)
+
+## Notes
+
+## Attendance


### PR DESCRIPTION
Documented the Kokkos Developer Meeting held on October 29, 2025, including attendance, community updates, CI testing information, and discussions on various topics.