### PR TITLE
Update meeting notes for November 5, 2025

### DIFF
--- a/meeting_notes/kokkos-core/dev-meeting/2025/2025-11-05.md
+++ b/meeting_notes/kokkos-core/dev-meeting/2025/2025-11-05.md
@@ -69,6 +69,16 @@ approved pull requests: https://github.com/kokkos/kokkos/pulls?q=sort%3Aupdated-
 ### Priority
 
 - MDRangePolicy performance improvement is high priority
+  - Exploring Unrolling https://github.com/kokkos/kokkos/pull/8629
+  - Refactoring of device iterate tile https://github.com/kokkos/kokkos/pull/8638
+
+- MDRangePolicy Issues
+  - Fix custom reduction (blocker for tile size tuning) https://github.com/kokkos/kokkos/pull/8647
+  - Unrolling semantics proposal https://github.com/kokkos/kokkos/issues/8632
+
+- MDRangePolicy benchmarks
+  - Stream like https://github.com/kokkos/kokkos/pull/8462
+  - Stencil like https://github.com/kokkos/kokkos/pull/8458
   
 ## Publications
 


### PR DESCRIPTION
Added updates on MDRangePolicy performance improvements, issues, and benchmarks.