### PR TITLE
Add agenda for Kokkos-Kernels meeting on June 18, 2026

### DIFF
--- a/meeting_notes/kokkos_kernels_devs/agenda/2026-06-18.md
+++ b/meeting_notes/kokkos_kernels_devs/agenda/2026-06-18.md
@@ -1,0 +1,87 @@
+# Thursday, June 18th, 2026 Kokkos-Kernels Developer Meeting
+
+## Travel
+
+- Luc: June 12th - 26th CEA meeting and ISC
+
+## Community
+  
+## Testing
+
+### CI
+
+- Grace-Hopper machine at Sandia is running but not picking the job, still debugging with our CI team.
+- Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE image is ready, mostly includes an update cmake, and we are will create the action later today or next week
+- Upgrading rocm to 7.2.1 from the current 6.4.3 I believe...
+- Also looking into add CPU build with ipcx and MKL support, I do not see one and users are still using MKL a lot.
+- One more for RDC (rellocatable device code) for good measure... still only planning phase for this.
+
+### Nightly
+
+- [Kokkos Kernels](https://my.cdash.org/index.php?project=Kokkos+Kernels)' CDash
+  - Aurora back online, the build worked for a few days before hitting issues.
+    - I have a PR with a fix for gtest.h but I also noticed an issue with mirroring and that one I am not sure how to fix
+    - Fixing the "update" stage of the pipeline would be nice but I have no idea how to do that?
+  - Updated the testing logic on Polaris, still having issues with "Update" stage and one Benchmark bug needs to be fixed...
+  - nightly - olcf: trying to properly setup ctest [#3090](https://github.com/kokkos/kokkos-kernels/pull/3090) merged
+
+## Documentation, Communication Structures
+
+Not too much going on here, still some items to resolve:
+
+- Table for sparse Kernels to make it easier to navigate
+- Notice that a lot of public batched kernels are not tracked... will update kokkos-kernels/scripts/check_api_updates.py to pick them up
+- Need to push on the paper and get it moved out for review...
+
+## Release
+
+### 5.2
+
+Target release candidate: end of June
+Target release: early/mid July
+- Junchao's issue with atomics function warning was not picked up in 5.1.1 but will be in 5.2
+- Look at more ArmPL support in conjunction with CI work
+- PR [#3060](https://github.com/kokkos/kokkos-kernels/pull/3060) merged
+- Junchao: noticed some deprecation warning with a recent CUDA 13.3 build, let us have a look before the release!
+- icpx 2026 unit-test failures: Collen may help reporting
+- Sycl-CI failure: `sparse_block_spgemm_double_int_size_t_TestDevice` and `sycl_test.sparse_bsr_gauss_seidel_rank1_double_int64_t_int_TestDevice`
+
+```
+[ RUN      ] sycl_test.sparse_block_spgemm_double_int_size_t_TestDevice
+nentries_actual:1564 nentries_reference:2423
+/home/runner/_work/kokkos-kernels/kokkos-kernels/kokkos-kernels/sparse/unit_test/Test_Sparse_bspgemm.hpp:203: Failure
+
+[ RUN      ] sycl_test.sparse_bsr_gauss_seidel_rank1_double_int64_t_int_TestDevice
+unknown file: Failure
+Unknown C++ exception thrown in the test body.
+[  FAILED  ] sycl_test.sparse_bsr_gauss_seidel_rank1_double_int64_t_int_TestDevice (1226 ms)
+[ RUN      ] sycl_test.sparse_bsr_gauss_seidel_rank2_double_int64_t_int_TestDevice
+unknown file: Failure
+Unknown C++ exception thrown in the test body.
+[  FAILED  ] sycl_test.sparse_bsr_gauss_seidel_rank2_double_int64_t_int_TestDevice (1836 ms)
+```
+
+- Sycl-sparse API has changed: warning still exists? ([#3131](https://github.com/kokkos/kokkos-kernels/pull/3131) merged)
+
+#### To Discuss / Resolve
+
+- refactoring TeamVectorGEMM:
+  - PR [#2628](https://github.com/kokkos/kokkos-kernels/pull/2628) merged
+
+- Reintroduce ConjTrans support for TeamGemm:
+  - PR [#3085](https://github.com/kokkos/kokkos-kernels/pull/3085) merged
+ 
+- Add genuine l1 norm:
+  - PR [#3150](https://github.com/kokkos/kokkos-kernels/pull/3150) --> Blas or mathematical norm computation
+
+- refactoring TPL build system
+  - Remove logic that include TPL into the kokkos:: namespace and instead introduce them in kokkoskernels::
+
+- sycl align ptr tests
+  - Not sure what we are trying to do in [Test_Common_AlignPtrTo.hpp](https://github.com/kokkos/kokkos-kernels/blob/develop/common/unit_test/Test_Common_AlignPtrTo.hpp) reviewing it and deciding if it is worth the trouble would be good. It is currently failing in a nightly build on Blake...
+ 
+
+#### Current issues:
+
+- Junchao: is Kokkos Kernels supporting 64bit integers for cuSPARSE matrix-vector product?
+  - Luc: it looks like we have a code path and some infrastructure to support it, a test case from a user would be good, we would fallback to native implementation otherwise.


### PR DESCRIPTION
Documented the agenda for the Kokkos-Kernels Developer Meeting on June 18, 2026, including travel plans, community updates, testing status, documentation needs, and release targets.