### PR TITLE
Create agenda for Kokkos-Kernels meeting on 2026-06-19

### DIFF
--- a/meeting_notes/kokkos_kernels_devs/agenda/2026-06-19-CEA.md
+++ b/meeting_notes/kokkos_kernels_devs/agenda/2026-06-19-CEA.md
@@ -1,0 +1,36 @@
+# Friday, June 19th, 2026 Kokkos-Kernels Developer Meeting
+
+## Travel
+
+- Luc: June 12th - 26th CEA meeting and ISC
+
+## Community
+  
+## Points
+
+- Kokkos-kernels batched design
+  - If Blas/Lapck naming, we would like to implement in the exactly same way
+  - Slightly different name, we have more freedom
+  - Self-similarity can help
+  - Performance report against roofline -> proceedings?
+  - Data analytics needed for performance results. Data model (bunch of json files, SQL?)
+  - Overlay performance with other machines
+  - IterateLeft/IterateRight may be possible
+  - Design specification for new functions
+
+- Tpl support design in the ecosystem
+  - OpenBlas set number of threads, through command line
+  - Initialization/Finalization at other ecosystem libraries?
+  - Initialize Tpls? Egar initialize waiting for the first call. `KokkosFFT::setup()`.
+  - How to initialize comm? Kokkos Comm takes `MPI_Comm`. 
+  - How to manage handles? Singleton in Kokkos-kernels.
+  - Difficulty: Many functions in Sparse. One singleton is enough? Subhandle?
+  - Main handle: Sparse handle has a subhandle for spgemm. Can be a zombie holding a lot of memory. User needs to release by themselves.
+  - You can only have one handle. Create a new one from main handle. User will allocate.
+  - Plans are indenpendent in KokkosFFT.
+  - CMake design with Jacob.
+
+- Kokkos-kernels priority
+  
+- Kokkos-kernels must fix issues before 5.2 release
+  - See meeting note 2026-06-18.md. Collen may help fixing the issues in Sycl backend


### PR DESCRIPTION
Added agenda for the Kokkos-Kernels developer meeting on June 19, 2026, including travel details, community points, and discussion topics.