### PR TITLE
Revise meeting notes for August 5, 2026

### DIFF
--- a/meeting_notes/kokkos-core/dev-meeting/2026/2026-08-05.md
+++ b/meeting_notes/kokkos-core/dev-meeting/2026/2026-08-05.md
@@ -1,4 +1,4 @@
-## Wednesday, July 29, 2026 Kokkos Developer Meeting
+## Wednesday, August 5, 2026 Kokkos Developer Meeting
 
 
 ## Linux Foundation Meeting Link
@@ -70,7 +70,7 @@ approved pull requests: https://github.com/kokkos/kokkos/pulls?q=sort%3Aupdated-
 
 ## Publications
 
-- MDRange optimization paper consideration for SC workshops
+- MDRange optimization paper consideration for [P3HPC](https://p3hpc.org/workshop/2026/) workshops. The first draft distributed among co-authors.
 - Possible papers we could focus on
   - New Kokkos ecosystem paper mentioning new efforts and the transition to HPSF
     - waiting for Comm blog post, and maybe Fortran Interop


### PR DESCRIPTION
Updated the date and added a link to the P3HPC workshop in the meeting notes.